### PR TITLE
Upgrade complate-fractal dependency

### DIFF
--- a/components/01-atoms/form/button/button.html
+++ b/components/01-atoms/form/button/button.html
@@ -1,18 +1,15 @@
-import { Fragment } from 'complate-stream'
 import Button from "./components/01-atoms/form/button/index.jsx";
 
-<Fragment>
-    <div class="demo">
-        <Button size="small">Small Button</Button>
-        <Button size="medium">Medium Button</Button>
-        <Button size="large">Large Button</Button>
-        <Button light>Large Button</Button>
-        <Button cta>Call To Action Button</Button>
-    </div>
-    <div class="demo demo--inverted">
-        <Button size="small" inverted>Small Button inverted</Button>
-        <Button size="medium" inverted>Medium Button inverted</Button>
-        <Button size="large" inverted>Large Button inverted</Button>
-        <Button light inverted>Large Button inverted</Button>
-    </div>
-</Fragment>
+<div class="demo">
+    <Button size="small">Small Button</Button>
+    <Button size="medium">Medium Button</Button>
+    <Button size="large">Large Button</Button>
+    <Button light>Large Button</Button>
+    <Button cta>Call To Action Button</Button>
+</div>
+<div class="demo demo--inverted">
+    <Button size="small" inverted>Small Button inverted</Button>
+    <Button size="medium" inverted>Medium Button inverted</Button>
+    <Button size="large" inverted>Large Button inverted</Button>
+    <Button light inverted>Large Button inverted</Button>
+</div>

--- a/components/01-atoms/text/block/heading/heading.html
+++ b/components/01-atoms/text/block/heading/heading.html
@@ -1,16 +1,13 @@
-import { Fragment } from 'complate-stream'
 import { SectionHeading } from './components/01-atoms/text/block/heading'
 
-<Fragment>
-    <h1>Heading H1</h1>
-    <h2>Heading H2</h2>
-    <h3>Heading H3</h3>
-    <h4>Heading H4</h4>
-    <h5>Heading H5</h5>
-    <h6>Heading H6</h6>
+<h1>Heading H1</h1>
+<h2>Heading H2</h2>
+<h3>Heading H3</h3>
+<h4>Heading H4</h4>
+<h5>Heading H5</h5>
+<h6>Heading H6</h6>
 
-    <h2 class="teaser-section-heading">Teaser Section Heading</h2>
-    <SectionHeading primary>Section Heading Primary</SectionHeading>
-    <SectionHeading secondary>Section Heading Secondary</SectionHeading>
-    <SectionHeading tertiary>Section Heading Tertiary</SectionHeading>
-</Fragment>
+<h2 class="teaser-section-heading">Teaser Section Heading</h2>
+<SectionHeading primary>Section Heading Primary</SectionHeading>
+<SectionHeading secondary>Section Heading Secondary</SectionHeading>
+<SectionHeading tertiary>Section Heading Tertiary</SectionHeading>

--- a/components/01-atoms/text/block/label/label.html
+++ b/components/01-atoms/text/block/label/label.html
@@ -1,23 +1,20 @@
-import { Fragment } from 'complate-stream'
 import Label from './components/01-atoms/text/block/label'
 
-<Fragment>
-    <Label type="talk">
-        Vortrag
-    </Label>
-    <Label type="training">
-        Training
-    </Label>
-    <Label type="slides">
-        Folien verfügbar
-    </Label>
-    <Label type="hint" big>
-        Ausverkauft!
-    </Label>
-    <Label type="badge" big>
-        Neu!
-    </Label>
-    <Label type="badge" big inverted>
-        Neu!
-    </Label>
-</Fragment>
+<Label type="talk">
+    Vortrag
+</Label>
+<Label type="training">
+    Training
+</Label>
+<Label type="slides">
+    Folien verfügbar
+</Label>
+<Label type="hint" big>
+    Ausverkauft!
+</Label>
+<Label type="badge" big>
+    Neu!
+</Label>
+<Label type="badge" big inverted>
+    Neu!
+</Label>

--- a/components/02-molecules/teaser/list-teaser/case-list-teaser/case-list-teaser.html
+++ b/components/02-molecules/teaser/list-teaser/case-list-teaser/case-list-teaser.html
@@ -1,17 +1,14 @@
-import { Fragment } from 'complate-stream'
 import CaseListTeaser from "./components/02-molecules/teaser/list-teaser/case-list-teaser"
 
-<Fragment>
-    <div class="blocks">
-        <CaseListTeaser header="case study headline eggs" caption="case study" href="#" linkText="mehr erfahren" additionalClasses="topic-header-bg-image-girl" headerAdditionalClasses="topic-header-bg-image-text-box-girl" punchIn>
-            lorem ipsum dolor sit amet, consectetur adipisicing elit. velit doloremque culpa minima vero quod, optio itaque nisi deserunt, debitis ad laudantium libero, quia nemo!
-        </CaseListTeaser>
-    </div>
+<div class="blocks">
+    <CaseListTeaser header="case study headline eggs" caption="case study" href="#" linkText="mehr erfahren" additionalClasses="topic-header-bg-image-girl" headerAdditionalClasses="topic-header-bg-image-text-box-girl" punchIn>
+        lorem ipsum dolor sit amet, consectetur adipisicing elit. velit doloremque culpa minima vero quod, optio itaque nisi deserunt, debitis ad laudantium libero, quia nemo!
+    </CaseListTeaser>
+</div>
 
-    <div class="blocks">
-        <CaseListTeaser header="Case Study Headline" caption="Case Study" href="#" linkText="mehr erfahren"
-            additionalClasses="landing-page-header-bg-image" simple withButton>
-            lorem ipsum dolor sit amet, consectetur adipisicing elit. velit doloremque culpa minima vero quod, optio itaque nisi deserunt, debitis ad laudantium libero, quia nemo!
-        </CaseListTeaser>
-    </div>
-</Fragment>
+<div class="blocks">
+    <CaseListTeaser header="Case Study Headline" caption="Case Study" href="#" linkText="mehr erfahren"
+        additionalClasses="landing-page-header-bg-image" simple withButton>
+        lorem ipsum dolor sit amet, consectetur adipisicing elit. velit doloremque culpa minima vero quod, optio itaque nisi deserunt, debitis ad laudantium libero, quia nemo!
+    </CaseListTeaser>
+</div>

--- a/components/02-molecules/teaser/list-teaser/training-list-teaser/training-list-teaser.html
+++ b/components/02-molecules/teaser/list-teaser/training-list-teaser/training-list-teaser.html
@@ -1,12 +1,9 @@
-import { Fragment } from 'complate-stream'
 import TrainingListTeaser from './components/02-molecules/teaser/list-teaser/training-list-teaser/index.jsx'
 import Label from './components/01-atoms/text/block/label/index.jsx'
 
-<Fragment>
-    <TrainingListTeaser primary title="Titel" subtitle="Untertitel" linkText="Termine & Details">
-        <Label type="badge" big inverted>Labeltext</Label>
-    </TrainingListTeaser>
-    <TrainingListTeaser secondary title="Titel" subtitle="Untertitel" linkText="Termine & Details">
-        <Label type="badge" big>Labeltext</Label>
-    </TrainingListTeaser>
-</Fragment>
+<TrainingListTeaser primary title="Titel" subtitle="Untertitel" linkText="Termine & Details">
+    <Label type="badge" big inverted>Labeltext</Label>
+</TrainingListTeaser>
+<TrainingListTeaser secondary title="Titel" subtitle="Untertitel" linkText="Termine & Details">
+    <Label type="badge" big>Labeltext</Label>
+</TrainingListTeaser>

--- a/components/02-molecules/teaser/tile-teaser/case-tile-teaser/case-tile-teaser.html
+++ b/components/02-molecules/teaser/tile-teaser/case-tile-teaser/case-tile-teaser.html
@@ -1,29 +1,26 @@
-import { Fragment } from 'complate-stream'
 import CaseTileTeaser from './components/02-molecules/teaser/tile-teaser/case-tile-teaser'
 
-<Fragment>
-    <div class="blocks">
-        <CaseTileTeaser size="bg" additionalClassnames="case-tile-teaser-bg-image-demo" href="#" caption="Case Study" headline="Dies ist eine Headline" linkTeaser="zum Projekt">
-          Lorem gibson 8-bit Freeside denim otaku sign boy neon warp long-chain hydrocarbons car.
-          Qui excepteur laborum ea est culpa reprehenderit enim ex amet veniam excepteur. Minim aliqua amet reprehenderit id velit id dolor quis et ea anim in. Cillum nisi ex incididunt id adipisicing reprehenderit id dolor qui anim non velit. Laboris esse ex duis sit labore culpa quis duis. Irure tempor deserunt et velit labore excepteur pariatur aute adipisicing eu do cupidatat nisi. Cupidatat officia aliquip excepteur Lorem in. Cillum amet enim anim do ut do adipisicing excepteur proident aute.
-        </CaseTileTeaser>
+<div class="blocks">
+    <CaseTileTeaser size="bg" additionalClassnames="case-tile-teaser-bg-image-demo" href="#" caption="Case Study" headline="Dies ist eine Headline" linkTeaser="zum Projekt">
+      Lorem gibson 8-bit Freeside denim otaku sign boy neon warp long-chain hydrocarbons car.
+      Qui excepteur laborum ea est culpa reprehenderit enim ex amet veniam excepteur. Minim aliqua amet reprehenderit id velit id dolor quis et ea anim in. Cillum nisi ex incididunt id adipisicing reprehenderit id dolor qui anim non velit. Laboris esse ex duis sit labore culpa quis duis. Irure tempor deserunt et velit labore excepteur pariatur aute adipisicing eu do cupidatat nisi. Cupidatat officia aliquip excepteur Lorem in. Cillum amet enim anim do ut do adipisicing excepteur proident aute.
+    </CaseTileTeaser>
 
-        <CaseTileTeaser size="bg" additionalClassnames="case-tile-teaser-bg-image-demo" href="#" caption="Case Study" headline="Dies ist eine Headline" linkTeaser="zum Projekt">
-            Lorem gibson 8-bit Freeside denim otaku sign boy neon warp long-chain hydrocarbons car.
-        </CaseTileTeaser>
-    </div>
+    <CaseTileTeaser size="bg" additionalClassnames="case-tile-teaser-bg-image-demo" href="#" caption="Case Study" headline="Dies ist eine Headline" linkTeaser="zum Projekt">
+        Lorem gibson 8-bit Freeside denim otaku sign boy neon warp long-chain hydrocarbons car.
+    </CaseTileTeaser>
+</div>
 
-    <div class="blocks">
-        <CaseTileTeaser size="sm" additionalClassnames="case-tile-teaser-bg-image-demo" href="#" caption="Case Study" headline="Dies ist eine Headline" linkTeaser="zum Projekt">
-            Lorem gibson 8-bit Freeside denim otaku sign boy neon warp long-chain hydrocarbons car.
-        </CaseTileTeaser>
+<div class="blocks">
+    <CaseTileTeaser size="sm" additionalClassnames="case-tile-teaser-bg-image-demo" href="#" caption="Case Study" headline="Dies ist eine Headline" linkTeaser="zum Projekt">
+        Lorem gibson 8-bit Freeside denim otaku sign boy neon warp long-chain hydrocarbons car.
+    </CaseTileTeaser>
 
-        <CaseTileTeaser size="sm" additionalClassnames="case-tile-teaser-bg-image-demo" href="#" caption="Case Study" headline="Dies ist eine Headline" linkTeaser="zum Projekt">
-            Lorem gibson 8-bit Freeside denim otaku sign boy neon warp long-chain hydrocarbons car.
-        </CaseTileTeaser>
+    <CaseTileTeaser size="sm" additionalClassnames="case-tile-teaser-bg-image-demo" href="#" caption="Case Study" headline="Dies ist eine Headline" linkTeaser="zum Projekt">
+        Lorem gibson 8-bit Freeside denim otaku sign boy neon warp long-chain hydrocarbons car.
+    </CaseTileTeaser>
 
-        <CaseTileTeaser size="sm" additionalClassnames="case-tile-teaser-bg-image-demo" href="#" caption="Case Study" headline="Dies ist eine Headline" linkTeaser="zum Projekt">
-            Lorem gibson 8-bit Freeside denim otaku sign boy neon warp long-chain hydrocarbons car.
-        </CaseTileTeaser>
-    </div>
-</Fragment>
+    <CaseTileTeaser size="sm" additionalClassnames="case-tile-teaser-bg-image-demo" href="#" caption="Case Study" headline="Dies ist eine Headline" linkTeaser="zum Projekt">
+        Lorem gibson 8-bit Freeside denim otaku sign boy neon warp long-chain hydrocarbons car.
+    </CaseTileTeaser>
+</div>

--- a/components/02-molecules/teaser/tile-teaser/simple-tile-teaser/simple-tile-teaser.html
+++ b/components/02-molecules/teaser/tile-teaser/simple-tile-teaser/simple-tile-teaser.html
@@ -1,15 +1,12 @@
-import { Fragment } from 'complate-stream'
 import SimpleTileTeaser from "./components/02-molecules/teaser/tile-teaser/simple-tile-teaser/index.jsx";
 
-<Fragment>
-    <div class="blocks">
-        <SimpleTileTeaser title="Teaser Titel" subtitle="Teaser Untertitel" buttonText="Hier klicken!"></SimpleTileTeaser>
-        <SimpleTileTeaser title="Teaser Titel" buttonText="Hier klicken!"></SimpleTileTeaser>
-        <SimpleTileTeaser title="Teaser Titel" subtitle="Teaser Untertitel" buttonText="Hier klicken!"></SimpleTileTeaser>
-    </div>
-    <div class="blocks">
-        <SimpleTileTeaser title="Teaser Titel" subtitle="Teaser Untertitel" buttonText="Hier klicken!"></SimpleTileTeaser>
-        <SimpleTileTeaser title="Teaser Titel" subtitle="Teaser Untertitel" buttonText="Hier klicken!"></SimpleTileTeaser>
-        <SimpleTileTeaser title="Teaser Titel" subtitle="Teaser Untertitel" buttonText="Hier klicken!"></SimpleTileTeaser>
-    </div>
-</Fragment>
+<div class="blocks">
+    <SimpleTileTeaser title="Teaser Titel" subtitle="Teaser Untertitel" buttonText="Hier klicken!"></SimpleTileTeaser>
+    <SimpleTileTeaser title="Teaser Titel" buttonText="Hier klicken!"></SimpleTileTeaser>
+    <SimpleTileTeaser title="Teaser Titel" subtitle="Teaser Untertitel" buttonText="Hier klicken!"></SimpleTileTeaser>
+</div>
+<div class="blocks">
+    <SimpleTileTeaser title="Teaser Titel" subtitle="Teaser Untertitel" buttonText="Hier klicken!"></SimpleTileTeaser>
+    <SimpleTileTeaser title="Teaser Titel" subtitle="Teaser Untertitel" buttonText="Hier klicken!"></SimpleTileTeaser>
+    <SimpleTileTeaser title="Teaser Titel" subtitle="Teaser Untertitel" buttonText="Hier klicken!"></SimpleTileTeaser>
+</div>


### PR DESCRIPTION
> `Fragment` is no longer needed for multiple top-level elements within
> sample snippets
>
> note that `Fragment` is already being imported by complate-fractal
> within snippets' scope, so snippets must not import it themselves