### PR TITLE
Clean podcast security page classes

### DIFF
--- a/components/02-molecules/visual-elements/teaser/list-teaser/podcast-list-teaser/podcast-list-teaser--security.html
+++ b/components/02-molecules/visual-elements/teaser/list-teaser/podcast-list-teaser/podcast-list-teaser--security.html
@@ -2,7 +2,7 @@ import { cssBoth } from "./components/02-molecules/visual-elements/teaser/list-t
 
 <a href="#" class="list-teaser-podcast list-teaser-podcast--avatar--overlay--big list-teaser-podcast--avatar--overlay--big--security" style={cssBoth}>
     <div class="list-teaser-podcast__body">
-        <div class="list-teaser-podcast__caption list-teaser-podcast__caption--security">Podcast</div>
+        <div class="list-teaser-podcast__caption list-teaser-podcast__caption--security">Security-Podcast</div>
         <h2 class="list-teaser-podcast__headline list-teaser-podcast__headline--security">Podcast Headline</h2>
         <h3 class="list-teaser-podcast__subheadline list-teaser-podcast__subheadline--security">
             Podcast Subheadline

--- a/components/02-molecules/visual-elements/teaser/tile-teaser/podcast-tile-teaser/podcast-tile-teaser--security.html
+++ b/components/02-molecules/visual-elements/teaser/tile-teaser/podcast-tile-teaser/podcast-tile-teaser--security.html
@@ -4,7 +4,7 @@ import { cssRight, cssBoth } from "./components/02-molecules/visual-elements/tea
     <div class="blocks">
         <a href="#" class="podcast-teaser podcast-teaser--avatar--overlay podcast-teaser--avatar--overlay--security" style={cssRight}>
             <div class="podcast-teaser__body">
-                <div class="podcast-teaser__caption podcast-teaser__caption--security">Podcast</div>
+                <div class="podcast-teaser__caption podcast-teaser__caption--security">Security-Podcast</div>
                 <h2 class="podcast-teaser__headline podcast-teaser__headline--security">Podcast Headline</h2>
                 <h3 class="podcast-teaser__subheadline podcast-teaser__subheadline--security">
                     Podcast Subheadline lorem ipsum dolor sit amet bla bla trololo.
@@ -19,7 +19,7 @@ import { cssRight, cssBoth } from "./components/02-molecules/visual-elements/tea
         </a>
         <a href="#" class="podcast-teaser podcast-teaser--default podcast-teaser--default--security">
             <div class="podcast-teaser__body">
-                <div class="podcast-teaser__caption podcast-teaser__caption--security">Podcast</div>
+                <div class="podcast-teaser__caption podcast-teaser__caption--security">Security-Podcast</div>
                 <h2 class="podcast-teaser__headline podcast-teaser__headline--security">Podcast Headline</h2>
                 <h3 class="podcast-teaser__subheadline podcast-teaser__subheadline--security">
                     Podcast Subheadline
@@ -38,7 +38,7 @@ import { cssRight, cssBoth } from "./components/02-molecules/visual-elements/tea
 
         <a href="#" class="podcast-teaser podcast-teaser--avatar podcast-teaser podcast-teaser--avatar--security" style={cssRight}>
             <div class="podcast-teaser__body">
-                <div class="podcast-teaser__caption podcast-teaser__caption--security">Podcast</div>
+                <div class="podcast-teaser__caption podcast-teaser__caption--security">Security-Podcast</div>
                 <h2 class="podcast-teaser__headline podcast-teaser__headline--security">Podcast Headline</h2>
                 <h3 class="podcast-teaser__subheadline podcast-teaser__subheadline--security">
                     Podcast Subheadline
@@ -56,7 +56,7 @@ import { cssRight, cssBoth } from "./components/02-molecules/visual-elements/tea
     <div class="blocks">
         <a href="#" class="podcast-teaser podcast-teaser--default podcast-teaser--default--security">
             <div class="podcast-teaser__body">
-                <div class="podcast-teaser__caption podcast-teaser__caption--security">Podcast</div>
+                <div class="podcast-teaser__caption podcast-teaser__caption--security">Security-Podcast</div>
                 <h2 class="podcast-teaser__headline podcast-teaser__headline--security">Podcast Headline</h2>
                 <h3 class="podcast-teaser__subheadline podcast-teaser__subheadline--security">
                     Podcast Subheadline
@@ -72,7 +72,7 @@ import { cssRight, cssBoth } from "./components/02-molecules/visual-elements/tea
 
         <a href="#" class="podcast-teaser podcast-teaser--avatar--overlay--big podcast-teaser--avatar--overlay--big--security" style={cssBoth}>
             <div class="podcast-teaser__body">
-                <div class="podcast-teaser__caption podcast-teaser__caption--security">Podcast</div>
+                <div class="podcast-teaser__caption podcast-teaser__caption--security">Security-Podcast</div>
                 <h2 class="podcast-teaser__headline podcast-teaser__headline--security">Podcast Headline</h2>
                 <h3 class="podcast-teaser__subheadline podcast-teaser__subheadline--security">
                       Podcast Subheadline
@@ -93,7 +93,7 @@ import { cssRight, cssBoth } from "./components/02-molecules/visual-elements/tea
     <div class="blocks">
         <a href="#" class="podcast-teaser podcast-teaser--avatar--overlay podcast-teaser--avatar--overlay--security" style={cssRight}>
             <div class="podcast-teaser__body">
-                <div class="podcast-teaser__caption podcast-teaser__caption--security">Podcast</div>
+                <div class="podcast-teaser__caption podcast-teaser__caption--security">Security-Podcast</div>
                 <h2 class="podcast-teaser__headline podcast-teaser__headline--security">Podcast Headline</h2>
                 <h3 class="podcast-teaser__subheadline podcast-teaser__subheadline--security">
                     Podcast Subheadline
@@ -112,7 +112,7 @@ import { cssRight, cssBoth } from "./components/02-molecules/visual-elements/tea
 
         <a href="#" class="podcast-teaser podcast-teaser--default podcast-teaser--default--security">
             <div class="podcast-teaser__body">
-                <div class="podcast-teaser__caption podcast-teaser__caption--security">Podcast</div>
+                <div class="podcast-teaser__caption podcast-teaser__caption--security">Security-Podcast</div>
                 <h2 class="podcast-teaser__headline podcast-teaser__headline--security">Podcast Headline</h2>
                 <h3 class="podcast-teaser__subheadline podcast-teaser__subheadline--security">
                     Podcast Subheadline

--- a/components/04-pages/podcast-pages/security-podcast/security-podcast-detail-page/_security-podcast-detail-page.scss
+++ b/components/04-pages/podcast-pages/security-podcast/security-podcast-detail-page/_security-podcast-detail-page.scss
@@ -1,7 +1,4 @@
 .podcast-detail-page--security {
-  * {
-    color: $brand-gray;
-  }
 
   a:not([class]):hover {
     background-color: $brand-yellow;
@@ -9,14 +6,15 @@
 
   .podcast-header--avatar--overlay {
     background-color: $brand-yellow;
-
-    > * {
-      color: $brand-gray;
-    }
   }
 
   .standard-header__intro__label {
     color: $brand-yellow;
+  }
+
+  .standard-header__title,
+  .standard-header__type {
+    color: $brand-gray;
   }
 
   .toolbar__link,

--- a/components/04-pages/podcast-pages/security-podcast/security-podcast-detail-page/security-podcast-detail-page.html
+++ b/components/04-pages/podcast-pages/security-podcast/security-podcast-detail-page/security-podcast-detail-page.html
@@ -1,7 +1,7 @@
 import { cssRight, cssBoth } from "./components/02-molecules/visual-elements/teaser/tile-teaser/podcast-tile-teaser/config";
 <main role="main" class="podcast-detail-page podcast-detail-page--security">
     <header class="standard-header podcast-header--avatar--overlay" style={cssBoth}>
-        <h3 class="standard-header__type">Podcast</h3>
+        <h3 class="standard-header__type">Security-Podcast</h3>
         <h1 class="standard-header__title">Podcast Titel</h1>
         <h2 class="standard-header__subtitle">Ein Untertitel</h2>
         <div class="standard-header__intro">

--- a/components/04-pages/podcast-pages/security-podcast/security-podcast-overview-page/_security-podcast-overview-page.scss
+++ b/components/04-pages/podcast-pages/security-podcast/security-podcast-overview-page/_security-podcast-overview-page.scss
@@ -17,21 +17,4 @@
       }
     }
   }
-
-  .podcast-teaser--avatar--overlay,
-  .podcast-teaser--avatar--overlay--big {
-    background-color: $brand-yellow;
-
-    * {
-      color: $brand-gray;
-    }
-  }
-
-  .podcast-teaser--default {
-    background-color: $brand-gray;
-
-    * {
-      color: $brand-yellow;
-    }
-  }
 }

--- a/components/04-pages/podcast-pages/security-podcast/security-podcast-overview-page/security-podcast-overview-page.html
+++ b/components/04-pages/podcast-pages/security-podcast/security-podcast-overview-page/security-podcast-overview-page.html
@@ -3,7 +3,7 @@ import { cssRight, cssBoth } from "./components/02-molecules/visual-elements/tea
     <header class="topic-header topic-header-bg-image-koralle">
         <div class="topic-header__body">
             <div>
-                <h1 class="topic-header__title topic-header-bg-image-text-box-girl">Der INNOQ Security Podcast</h1>
+                <h1 class="topic-header__title topic-header-bg-image-text-box-girl">Der Security Podcast</h1>
             </div>
             <div class="topic-header__text">
                 Filet mignon sausage tongue, hamburger porchetta fatback kielbasa flank
@@ -51,27 +51,27 @@ import { cssRight, cssBoth } from "./components/02-molecules/visual-elements/tea
 
     <article class="teaser-page-layout">
         <div class="podcast-grid">
-            <a href="#" class="podcast-teaser podcast-teaser--avatar--overlay" style={cssRight}>
+            <a href="#" class="podcast-teaser podcast-teaser--avatar--overlay podcast-teaser--avatar--overlay--security" style={cssRight}>
                 <div class="podcast-teaser__body">
-                    <div class="podcast-teaser__caption">Podcast</div>
-                    <h2 class="podcast-teaser__headline">Podcast Headline</h2>
-                    <h3 class="podcast-teaser__subheadline">
+                    <div class="podcast-teaser__caption">Security-Podcast</div>
+                    <h2 class="podcast-teaser__headline podcast-teaser__headline--security">Podcast Headline</h2>
+                    <h3 class="podcast-teaser__subheadline podcast-teaser__subheadline--security">
                         Podcast Subheadline
                     </h3>
                     <span class="icon-svg icon-arrow-long-right icon--brand-black"></span>
                 </div>
                 <div class="podcast-teaser__footer">
-                    <div class="podcast-author" itemscope itemtype="http://schema.org/Person" >
+                    <div class="podcast-author podcast-author--security" itemscope itemtype="http://schema.org/Person" >
                         Heribert Innoq
                     </div>
                 </div>
             </a>
 
-            <a href="#" class="podcast-teaser podcast-teaser--default">
+            <a href="#" class="podcast-teaser podcast-teaser--default podcast-teaser--default--security">
                 <div class="podcast-teaser__body">
-                    <div class="podcast-teaser__caption">Podcast</div>
-                    <h2 class="podcast-teaser__headline">Podcast Headline</h2>
-                    <h3 class="podcast-teaser__subheadline">
+                    <div class="podcast-teaser__caption">Security-Podcast</div>
+                    <h2 class="podcast-teaser__headline podcast-teaser__headline--security">Podcast Headline</h2>
+                    <h3 class="podcast-teaser__subheadline podcast-teaser__subheadline--security">
                         Podcast Subheadline
                     </h3>
                     <span class="icon-svg icon-arrow-long-right icon--brand-yellow"></span>
@@ -86,11 +86,11 @@ import { cssRight, cssBoth } from "./components/02-molecules/visual-elements/tea
                 </div>
             </a>
 
-            <a href="#" class="podcast-teaser podcast-teaser--avatar" style={cssRight}>
+            <a href="#" class="podcast-teaser podcast-teaser--avatar podcast-teaser--avatar--security" style={cssRight}>
                 <div class="podcast-teaser__body">
-                    <div class="podcast-teaser__caption">Podcast</div>
-                    <h2 class="podcast-teaser__headline">Podcast Headline</h2>
-                    <h3 class="podcast-teaser__subheadline">
+                    <div class="podcast-teaser__caption">Security-Podcast</div>
+                    <h2 class="podcast-teaser__headline podcast-teaser__headline--security">Podcast Headline</h2>
+                    <h3 class="podcast-teaser__subheadline podcast-teaser__subheadline--security">
                         Podcast Subheadline
                     </h3>
                     <span class="icon-svg icon-arrow-long-right icon--brand-black"></span>
@@ -102,11 +102,11 @@ import { cssRight, cssBoth } from "./components/02-molecules/visual-elements/tea
                 </div>
             </a>
 
-            <a href="#" class="podcast-teaser podcast-teaser--default">
+            <a href="#" class="podcast-teaser podcast-teaser--default podcast-teaser--default--security">
                 <div class="podcast-teaser__body">
-                    <div class="podcast-teaser__caption">Podcast</div>
-                    <h2 class="podcast-teaser__headline">Podcast Headline</h2>
-                    <h3 class="podcast-teaser__subheadline">
+                    <div class="podcast-teaser__caption">Security-Podcast</div>
+                    <h2 class="podcast-teaser__headline podcast-teaser__headline--security">Podcast Headline</h2>
+                    <h3 class="podcast-teaser__subheadline podcast-teaser__subheadline--security">
                         Podcast Subheadline
                     </h3>
                     <span class="icon-svg icon-arrow-long-right icon--brand-yellow"></span>
@@ -118,49 +118,49 @@ import { cssRight, cssBoth } from "./components/02-molecules/visual-elements/tea
                 </div>
             </a>
 
-            <a href="#" class="podcast-teaser podcast-teaser--avatar--overlay--big" style={cssBoth}>
+            <a href="#" class="podcast-teaser podcast-teaser--avatar--overlay--big podcast-teaser--avatar--overlay--big--security" style={cssBoth}>
                 <div class="podcast-teaser__body">
-                    <div class="podcast-teaser__caption">Podcast</div>
-                    <h2 class="podcast-teaser__headline">Podcast Headline</h2>
-                    <h3 class="podcast-teaser__subheadline">
+                    <div class="podcast-teaser__caption">Security-Podcast</div>
+                    <h2 class="podcast-teaser__headline podcast-teaser__headline--security">Podcast Headline</h2>
+                    <h3 class="podcast-teaser__subheadline podcast-teaser__subheadline--security">
                         Podcast Subheadline
                     </h3>
                     <span class="icon-svg icon-arrow-long-right icon--brand-black"></span>
                 </div>
                 <div class="podcast-teaser__footer">
-                    <div class="podcast-author" itemscope itemtype="http://schema.org/Person" >
+                    <div class="podcast-author podcast-author--security" itemscope itemtype="http://schema.org/Person" >
                         Heribert Innoq
                     </div>
-                    <div class="podcast-author" itemscope itemtype="http://schema.org/Person" >
+                    <div class="podcast-author podcast-author--security" itemscope itemtype="http://schema.org/Person" >
                         Heribert Innoq
                     </div>
                 </div>
             </a>
 
-            <a href="#" class="podcast-teaser podcast-teaser--avatar--overlay" style={cssRight}>
+            <a href="#" class="podcast-teaser podcast-teaser--avatar--overlay podcast-teaser--avatar--overlay--security" style={cssRight}>
                 <div class="podcast-teaser__body">
-                    <div class="podcast-teaser__caption">Podcast</div>
-                    <h2 class="podcast-teaser__headline">Podcast Headline</h2>
-                    <h3 class="podcast-teaser__subheadline">
+                    <div class="podcast-teaser__caption">Security-Podcast</div>
+                    <h2 class="podcast-teaser__headline podcast-teaser__headline--security">Podcast Headline</h2>
+                    <h3 class="podcast-teaser__subheadline podcast-teaser__subheadline--security">
                         Podcast Subheadline
                     </h3>
                     <span class="icon-svg icon-arrow-long-right icon--brand-black"></span>
                 </div>
                 <div class="podcast-teaser__footer">
-                    <div class="podcast-author" itemscope itemtype="http://schema.org/Person" >
+                    <div class="podcast-author podcast-author--security" itemscope itemtype="http://schema.org/Person" >
                         Heribert Innoq
                     </div>
-                    <div class="podcast-author" itemscope itemtype="http://schema.org/Person" >
+                    <div class="podcast-author podcast-author--security" itemscope itemtype="http://schema.org/Person" >
                         Heribert Innoq
                     </div>
                 </div>
             </a>
 
-            <a href="#" class="podcast-teaser podcast-teaser--default">
+            <a href="#" class="podcast-teaser podcast-teaser--default podcast-teaser--default--security">
                 <div class="podcast-teaser__body">
-                    <div class="podcast-teaser__caption">Podcast</div>
-                    <h2 class="podcast-teaser__headline">Podcast Headline</h2>
-                    <h3 class="podcast-teaser__subheadline">
+                    <div class="podcast-teaser__caption">Security-Podcast</div>
+                    <h2 class="podcast-teaser__headline podcast-teaser__headline--security">Podcast Headline</h2>
+                    <h3 class="podcast-teaser__subheadline podcast-teaser__subheadline--security">
                         Podcast Subheadline
                     </h3>
                     <span class="icon-svg icon-arrow-long-right icon--brand-yellow"></span>


### PR DESCRIPTION
- Security-Page-Klassen durch entsprechende (Tile/List-)Teaser-Klassen ersetzt, wo möglich, um die Kacheln modularer einsetzen zu können (und "falsche" Teaser nicht mit Sec-Farben zu überpinseln, Bsp. Recommendations)
- Caption angepasst 