### PR TITLE
Implement podcast overview design

### DIFF
--- a/components/02-molecules/visual-elements/teaser/tile-teaser/standard-tile-teaser/_standard-tile-teaser.scss
+++ b/components/02-molecules/visual-elements/teaser/tile-teaser/standard-tile-teaser/_standard-tile-teaser.scss
@@ -1,0 +1,109 @@
+$case-tile-teaser-sm-height: ms(32);
+
+// demo bg image
+// class for case tile teaser
+
+.standard-tile-teaser-bg-image-demo {
+  background-image: asset-url('visual-header-igel-1444.jpg');
+  background-position: center;
+}
+
+.standard-tile-teaser-bg-image-training {
+  background-image: asset-url('visual-newsletter.jpg');
+  background-position: top;
+}
+
+// class for podcast overview teaser
+
+.standard-tile-teaser-bg-color {
+  background-color: $podcast-teaser-overlay-color;
+  background-position: center;
+
+  &--security {
+    background-color: $podcast-teaser-overlay-color-sec;
+  }
+}
+
+
+.standard-tile-teaser {
+  @extend %block-link;
+  @extend %hover-zoom-in;
+
+  display: flex;
+  flex-direction: column;
+  background-size: cover;
+  padding: $spacer-sm $spacer-xs;
+}
+
+.standard-tile-teaser__content {
+  display: flex;
+  flex-direction: column;
+  flex-grow: 1;
+  justify-content: space-between;
+  background-color: $case-tile-teaser-body-bg-color;
+  padding: $spacer-md;
+}
+
+.standard-tile-teaser__body {
+  text-align: center;
+}
+
+.standard-tile-teaser__caption {
+  @extend %teaser-caption;
+  margin: 0;
+}
+
+.standard-tile-teaser__headline {
+  margin: $spacer-xs 0;
+}
+
+.standard-tile-teaser__text {
+  @extend %teaser-text-italic;
+}
+
+.standard-tile-teaser__goto {
+  text-align: center;
+}
+
+//
+// case-tile-teaser--sm
+//
+.standard-tile-teaser--sm {
+  margin-bottom: $spacer-xxl;
+  padding: $spacer-md;
+  min-height: $case-tile-teaser-sm-height;
+}
+
+.standard-tile-teaser__content--sm {
+  position: relative;
+  top: $spacer-xxl;
+  justify-content: space-between;
+  padding: $spacer-sm;
+}
+
+.standard-tile-teaser__headline--sm {
+  font-size: $teaser-headline-font-size-small;
+}
+
+.standard-tile-teaser__text--sm {
+  margin-bottom: $spacer-xs;
+  font-size: $teaser-text-font-size-italic-small;
+}
+
+//
+// Breakpoints
+//
+@media screen and (min-width: $grid-breakpoint-md) {
+  .standard-tile-teaser {
+    padding: $spacer-xl $spacer-lg;
+
+    &--narrow {
+      padding: $spacer-sm $spacer-xs;
+    }
+  }
+
+  .standard-tile-teaser__content {
+    padding: $spacer-lg;
+  }
+
+}

--- a/components/02-molecules/visual-elements/teaser/tile-teaser/standard-tile-teaser/standard-tile-teaser.config.yml
+++ b/components/02-molecules/visual-elements/teaser/tile-teaser/standard-tile-teaser/standard-tile-teaser.config.yml
@@ -1,0 +1,1 @@
+status: ready

--- a/components/02-molecules/visual-elements/teaser/tile-teaser/standard-tile-teaser/standard-tile-teaser.html
+++ b/components/02-molecules/visual-elements/teaser/tile-teaser/standard-tile-teaser/standard-tile-teaser.html
@@ -1,8 +1,8 @@
 <div class="blocks">
-    <a href="#" class="standard-tile-teaser standard-tile-teaser-bg-image-demo">
+    <a href="#" class="standard-tile-teaser standard-tile-teaser-bg-color">
         <div class="standard-tile-teaser__content">
             <div class="standard-tile-teaser__body">
-                <h2 class="standard-tile-teaser__caption">Case Study</h2>
+                <h2 class="standard-tile-teaser__caption">Unsere Podcasts</h2>
                 <h2 class="standard-tile-teaser__headline">Dies ist eine Headline</h2>
                 <div class="standard-tile-teaser__text">
                     Lorem gibson 8-bit Freeside denim otaku sign boy neon warp long-chain
@@ -17,30 +17,69 @@
                 </div>
             </div>
             <div class="standard-tile-teaser__goto">
-                <span class="link-teaser">zum Projekt</span>
+                <span class="link-teaser">Alle Episoden</span>
             </div>
         </div>
-    </a><a href="#" class="standard-tile-teaser standard-tile-teaser-bg-image-demo">
+    </a>
+
+    <a href="#" class="standard-tile-teaser standard-tile-teaser--narrow standard-tile-teaser-bg-color">
         <div class="standard-tile-teaser__content">
             <div class="standard-tile-teaser__body">
-                <h2 class="standard-tile-teaser__caption">Case Study</h2>
+                <h2 class="standard-tile-teaser__caption">Unsere Podcasts</h2>
                 <h2 class="standard-tile-teaser__headline">Dies ist eine Headline</h2>
+                <div class="standard-tile-teaser__text">
+                    Lorem gibson 8-bit Freeside denim otaku sign boy neon warp long-chain
+                    hydrocarbons car. Qui excepteur laborum ea est culpa reprehenderit
+                    enim ex amet veniam excepteur. Minim aliqua amet reprehenderit id
+                    velit id dolor quis et ea anim in. Cillum nisi ex incididunt id
+                    adipisicing reprehenderit id dolor qui anim non velit. Laboris esse ex
+                    duis sit labore culpa quis duis. Irure tempor deserunt et velit labore
+                    excepteur pariatur aute adipisicing eu do cupidatat nisi. Cupidatat
+                    officia aliquip excepteur Lorem in. Cillum amet enim anim do ut do
+                    adipisicing excepteur proident aute.
+                </div>
+            </div>
+            <div class="standard-tile-teaser__goto">
+                <span class="link-teaser">Alle Episoden</span>
+            </div>
+        </div>
+    </a>
+</div>
+<div class="blocks">
+    <a href="#" class="standard-tile-teaser standard-tile-teaser--narrow standard-tile-teaser-bg-color--security">
+        <div class="standard-tile-teaser__content">
+            <div class="standard-tile-teaser__body">
+                <h2 class="standard-tile-teaser__headline">Dies ist eine Headline ohne Caption</h2>
                 <div class="standard-tile-teaser__text">
                     Lorem gibson 8-bit Freeside denim otaku sign boy neon warp long-chain
                     hydrocarbons car.
                 </div>
             </div>
             <div class="standard-tile-teaser__goto">
-                <span class="link-teaser">zum Projekt</span>
+                <span class="link-teaser">Alle Episoden</span>
+            </div>
+        </div>
+    </a>
+    <a href="#" class="standard-tile-teaser standard-tile-teaser-bg-color--security">
+        <div class="standard-tile-teaser__content">
+            <div class="standard-tile-teaser__body">
+                <h2 class="standard-tile-teaser__headline">Dies ist eine Headline ohne Caption</h2>
+                <div class="standard-tile-teaser__text">
+                    Lorem gibson 8-bit Freeside denim otaku sign boy neon warp long-chain
+                    hydrocarbons car.
+                </div>
+            </div>
+            <div class="standard-tile-teaser__goto">
+                <span class="link-teaser">Alle Episoden</span>
             </div>
         </div>
     </a>
 </div>
 <div class="blocks">
-    <a href="#" class="standard-tile-teaser standard-tile-teaser-bg-image-demo standard-tile-teaser--sm">
+    <a href="#" class="standard-tile-teaser standard-tile-teaser-bg-color standard-tile-teaser--sm">
         <div class="standard-tile-teaser__content standard-tile-teaser__content--sm">
             <div class="standard-tile-teaser__body">
-                <h2 class="standard-tile-teaser__caption">Case Study</h2>
+                <h2 class="standard-tile-teaser__caption">Podcasts</h2>
                 <h2 class="standard-tile-teaser__headline standard-tile-teaser__headline--sm">
                     Dies ist eine Headline
                 </h2>
@@ -50,13 +89,14 @@
                 </div>
             </div>
             <div class="standard-tile-teaser__goto">
-                <span class="link-teaser">zum Projekt</span>
+                <span class="link-teaser">Alle Episoden</span>
             </div>
         </div>
-    </a><a href="#" class="standard-tile-teaser standard-tile-teaser-bg-image-demo standard-tile-teaser--sm">
+    </a>
+    <a href="#" class="standard-tile-teaser standard-tile-teaser-bg-color--security standard-tile-teaser--sm">
         <div class="standard-tile-teaser__content standard-tile-teaser__content--sm">
             <div class="standard-tile-teaser__body">
-                <h2 class="standard-tile-teaser__caption">Case Study</h2>
+                <h2 class="standard-tile-teaser__caption">Podcasts</h2>
                 <h2 class="standard-tile-teaser__headline standard-tile-teaser__headline--sm">
                     Dies ist eine Headline
                 </h2>
@@ -66,23 +106,7 @@
                 </div>
             </div>
             <div class="standard-tile-teaser__goto">
-                <span class="link-teaser">zum Projekt</span>
-            </div>
-        </div>
-    </a><a href="#" class="standard-tile-teaser standard-tile-teaser-bg-image-demo standard-tile-teaser--sm">
-        <div class="standard-tile-teaser__content standard-tile-teaser__content--sm">
-            <div class="standard-tile-teaser__body">
-                <h2 class="standard-tile-teaser__caption">Case Study</h2>
-                <h2 class="standard-tile-teaser__headline standard-tile-teaser__headline--sm">
-                    Dies ist eine Headline
-                </h2>
-                <div class="standard-tile-teaser__text standard-tile-teaser__text--sm">
-                    Lorem gibson 8-bit Freeside denim otaku sign boy neon warp long-chain
-                    hydrocarbons car.
-                </div>
-            </div>
-            <div class="standard-tile-teaser__goto">
-                <span class="link-teaser">zum Projekt</span>
+                <span class="link-teaser">Alle Episoden</span>
             </div>
         </div>
     </a>

--- a/components/04-pages/podcast-pages/podcast-overview-page/_podcast-overview-page.scss
+++ b/components/04-pages/podcast-pages/podcast-overview-page/_podcast-overview-page.scss
@@ -1,0 +1,67 @@
+.image-header--podcast {
+  padding: 0;
+}
+
+.podcast-overview-flex {
+  display: none;
+}
+
+.podcast-overview-teaser__headline--security,
+.podcast-overview-teaser__text--security {
+  color: $podcast-teaser-default-bg-sec;
+}
+
+.link-teaser--security {
+  border-bottom: 3px solid $podcast-teaser-overlay-color-sec;
+  color: $podcast-teaser-default-bg-sec;
+}
+
+
+
+@media screen and (min-width: $grid-breakpoint-md) {
+
+  .podcast-overview-grid {
+    display: grid;
+    grid-template-columns: 1fr;
+    grid-template-rows: 25% auto;
+  }
+
+  .podcast-overview-flex {
+    display: flex;
+    flex-wrap: wrap;
+    justify-content: space-between;
+  }
+
+  .flex-grow {
+    flex-grow: 1;
+  }
+}
+
+@media screen and (min-width: $grid-breakpoint-lg) {
+
+  .podcast-overview-grid {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    grid-auto-rows: 25% auto;
+  }
+
+  .grid-item1 {
+    grid-column: 1 / span 1;
+    grid-row: 1 / span 1;
+  }
+
+  .grid-item2 {
+    grid-column: 1 / span 1;
+    grid-row: 2 / span 1;
+  }
+
+  .grid-item3 {
+    grid-column: 2 / span 1;
+    grid-row: 1 / span 1;
+  }
+
+  .grid-item4 {
+    grid-column: 2 / span 1;
+    grid-row: 2 / span 1;
+  }
+}

--- a/components/04-pages/podcast-pages/podcast-overview-page/podcast-overview-page.config.yml
+++ b/components/04-pages/podcast-pages/podcast-overview-page/podcast-overview-page.config.yml
@@ -1,0 +1,1 @@
+status: wip

--- a/components/04-pages/podcast-pages/podcast-overview-page/podcast-overview-page.html
+++ b/components/04-pages/podcast-pages/podcast-overview-page/podcast-overview-page.html
@@ -1,0 +1,268 @@
+import { cssRight, cssBoth } from "./components/02-molecules/visual-elements/teaser/tile-teaser/podcast-tile-teaser/config";
+
+<main role="main">
+    <nav-bar class="navbar">
+        <div class="navbar__inner">
+            <a href="#main" class="navbtn navbtn--skip">Zum Inhalt springen</a>
+
+            <div class="navbar__brand">
+                <a href="#" class="navbar__brand-link">
+                    <img alt="inno Q" class="logo navbar__logo" src={context.app.uri('assets/innoq-logo--whitered.svg')} />
+                </a>
+            </div>
+
+            <input tabindex="-1" type="checkbox" id="navbar-toggle--menu" class="sr-only navbar__toggle-state navbar__toggle-state--menu-toggler" />
+            <input tabindex="-1" type="checkbox" id="navbar-toggle--search" class="sr-only navbar__toggle-state navbar__toggle-state--search-toggler" />
+
+            <div class="navbar__meta">
+                <a href="#" class="navbtn navbtn--meta">Newsletter</a>
+                <a href="#" class="navbtn navbtn--meta">Kontakt</a>
+                <a href="#" class="navbtn navbtn--meta navbtn--locale navbtn--active" title="Deutsch">de</a> |
+                <a href="#" class="navbtn navbtn--meta navbtn--locale" title="English">en</a>
+            </div>
+
+            <div class="navbar__togglers">
+                <label for="navbar-toggle--menu" aria-label="Navigation ein- oder ausblenden">
+                    <span class="navbtn navbtn--menu">Menü</span>
+                </label>
+                <a href="#" class="navbtn navbtn--search" aria-label="Suche ein- oder ausblenden">
+                    <i class="icon icon-search"></i>
+                </a>
+            </div>
+
+            <nav class="navbar__primary-nav primary-nav">
+                <ul class="primary-nav__list">
+                    <li class="primary-nav__item">
+                        <a href="#" class="navbtn navbtn--primary">Leistungen</a>
+                    </li>
+                    <li class="primary-nav__item">
+                        <div class="dropdown">
+                            <a href="#" class="navbtn navbtn--primary" data-for="dropdown__toggle--projekte">Projekte</a>
+                            <input type="checkbox" role="button" aria-haspopup="true" id="dropdown__toggle--projekte" class="sr-only dropdown__checkbox" />
+                            <label class="dropdown__toggle dropdown__toggle--navbar" for="dropdown__toggle--projekte">
+                                <i class="icon icon-chevron-2-down dropdown__icon dropdown__icon--navbar"></i>
+                                <span class="sr-only dropdown__toggle--expanded-text">ausgeklappt</span>
+                                <span class="sr-only dropdown__toggle--collapsed-text">eingeklappt</span>
+                            </label>
+                            <div class="dropdown__list-wrapper dropdown__list-wrapper--navbar" role="menu" title="Projekte" data-origin="left">
+                                <ul class="dropdown__list">
+                                    <li class="dropdown__item dropdown__item--navbar">
+                                        <a href="#" class="dropdown__link dropdown__link--navbar navbtn">Softwarearchitektur und -entwicklung</a>
+                                    </li>
+                                    <li class="dropdown__item dropdown__item--navbar">
+                                        <a href="#" class="dropdown__link dropdown__link--navbar navbtn">Strategie- und Technologieberatung</a>
+                                    </li>
+                                    <li class="dropdown__item dropdown__item--navbar">
+                                        <a href="#" class="dropdown__link dropdown__link--navbar navbtn">Entwicklung digitaler Geschäftsmodelle</a>
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="primary-nav__item">
+                        <div class="dropdown">
+                            <a href="#" class="navbtn navbtn--primary" data-for="dropdown__toggle--kultur">Kultur</a>
+                            <input type="checkbox" role="button" aria-haspopup="true" id="dropdown__toggle--kultur" class="sr-only dropdown__checkbox" />
+                            <label class="dropdown__toggle dropdown__toggle--navbar" for="dropdown__toggle--kultur">
+                                <i class="icon icon-chevron-2-down dropdown__icon dropdown__icon--navbar"></i>
+                                <span class="sr-only dropdown__toggle--expanded-text">ausgeklappt</span>
+                                <span class="sr-only dropdown__toggle--collapsed-text">eingeklappt</span>
+                            </label>
+                            <div class="dropdown__list-wrapper dropdown__list-wrapper--navbar" role="menu" title="Kultur" data-origin="right">
+                                <ul class="dropdown__list">
+                                    <li class="dropdown__item dropdown__item--navbar">
+                                        <a href="#" class="dropdown__link dropdown__link--navbar navbtn">Strategie- und Technologieberatung</a>
+                                    </li>
+                                    <li class="dropdown__item dropdown__item--navbar">
+                                        <a href="#" class="dropdown__link dropdown__link--navbar navbtn">Entwicklung digitaler Geschäftsmodelle</a>
+                                    </li>
+                                    <li class="dropdown__item dropdown__item--navbar">
+                                        <a href="#" class="dropdown__link dropdown__link--navbar navbtn">Softwarearchitektur und -entwicklung</a>
+                                    </li>
+                                    <li class="dropdown__item dropdown__item--navbar">
+                                        <a href="#" class="dropdown__link dropdown__link--navbar navbtn">Digitale Plattformen und Infrastrukturen</a>
+                                    </li>
+                                    <li class="dropdown__item dropdown__item--navbar">
+                                        <a href="#" class="dropdown__link dropdown__link--navbar navbtn">Wissenstransfer, Coaching und Trainings</a>
+                                    </li>
+                                </ul>
+                            </div>
+                        </div>
+                    </li>
+                    <li class="primary-nav__item">
+                        <a href="#" class="navbtn navbtn--primary  navbtn--active">Magazin</a>
+                    </li>
+                    <li class="primary-nav__item">
+                        <a href="#" class="navbtn navbtn--primary">Termine</a>
+                    </li>
+                </ul>
+                <button class="navbtn navbtn--drill-up">
+                    <img class="navbtn__left-icon" src={context.app.uri('assets/icons/arrow-medium-left-red.svg')} /> Hauptmenü
+                </button>
+            </nav>
+        </div>
+    </nav-bar>
+    <header class="image-header image-header--podcast">
+        <div class="image-header__body image-header-bg-culture-01">
+            <div class="image-header__content">
+                <h1 class="image-header__title image-header-bg-culture-01-text-box ">Unsere Podcasts</h1>
+                <img src={context.app.uri('assets/icons/arrow-long-down-red.svg')} />
+            </div>
+        </div>
+    </header>
+    <div class="podcast-overview-grid">
+        <div class="grid-item1">
+            <a href="#" class="standard-tile-teaser standard-tile-teaser--narrow standard-tile-teaser-bg-color">
+                <div class="standard-tile-teaser__content">
+                    <div class="standard-tile-teaser__body">
+                        <h2 class="standard-tile-teaser__headline">Der INNOQ Podcast</h2>
+                        <p class="standard-tile-teaser__text">
+                            In dieser Serie diskutieren wir interessante Themen aus Software-Entwicklung und -Architektur – immer mit dem Fokus auf Praxistauglichkeit.
+                        </p>
+                    </div>
+                    <div class="standard-tile-teaser__goto">
+                        <span class="link-teaser">Alle Episoden</span>
+                    </div>
+                </div>
+            </a>
+        </div>
+        <div class="grid-item2">
+            <div class="podcast-overview-flex">
+                <a href="#" class="podcast-teaser podcast-teaser--default flex-grow">
+                    <div class="podcast-teaser__body">
+                        <div class="podcast-teaser__caption">Podcast</div>
+                        <h2 class="podcast-teaser__headline">Podcast Headline</h2>
+                        <h3 class="podcast-teaser__subheadline">
+                            Podcast Subheadline
+                        </h3>
+                        <span class="icon-svg icon-arrow-long-right icon--brand-white"></span>
+                    </div>
+                    <div class="podcast-teaser__footer">
+                        <div class="podcast-author" itemscope itemtype="http://schema.org/Person" >
+                            Heribert Innoq
+                        </div>
+                    </div>
+                </a>
+                <a href="#" class="podcast-teaser podcast-teaser--avatar flex-grow" style={cssRight}>
+                    <div class="podcast-teaser__body">
+                        <div class="podcast-teaser__caption">Podcast</div>
+                        <h2 class="podcast-teaser__headline">Podcast Headline</h2>
+                        <h3 class="podcast-teaser__subheadline">
+                            Podcast Subheadline
+                        </h3>
+                        <span class="icon-svg icon-arrow-long-right icon--brand-white"></span>
+                    </div>
+                    <div class="podcast-teaser__footer">
+                        <div class="podcast-author" itemscope itemtype="http://schema.org/Person" >
+                            Heribert Innoq
+                        </div>
+                    </div>
+                </a>
+                <a href="#" class="podcast-teaser podcast-teaser--avatar--overlay flex-grow" style={cssRight}>
+                    <div class="podcast-teaser__body">
+                        <div class="podcast-teaser__caption">Podcast</div>
+                        <h2 class="podcast-teaser__headline">Podcast Headline</h2>
+                        <h3 class="podcast-teaser__subheadline">
+                            Podcast Subheadline
+                        </h3>
+                        <span class="icon-svg icon-arrow-long-right icon--brand-white"></span>
+                    </div>
+                    <div class="podcast-teaser__footer">
+                        <div class="podcast-author" itemscope itemtype="http://schema.org/Person" >
+                            Heribert Innoq
+                        </div>
+                    </div>
+                </a>
+                <a href="#" class="podcast-teaser podcast-teaser--avatar--overlay--big flex-grow style={cssRight}">
+                    <div class="podcast-teaser__body">
+                        <div class="podcast-teaser__caption">Podcast</div>
+                        <h2 class="podcast-teaser__headline">Podcast Headline</h2>
+                        <h3 class="podcast-teaser__subheadline">
+                            Podcast Subheadline
+                        </h3>
+                        <span class="icon-svg icon-arrow-long-right icon--brand-white"></span>
+                    </div>
+                    <div class="podcast-teaser__footer">
+                        <div class="podcast-author" itemscope itemtype="http://schema.org/Person" >
+                            Heribert Innoq
+                        </div>
+                        <div class="podcast-author" itemscope itemtype="http://schema.org/Person" >
+                            Heribert Innoq
+                        </div>
+                    </div>
+                </a>
+            </div>
+        </div>
+        <div class="grid-item3">
+            <a href="#" class="standard-tile-teaser standard-tile-teaser--narrow standard-tile-teaser-bg-color--security">
+                <div class="standard-tile-teaser__content">
+                    <div class="standard-tile-teaser__body">
+                        <h2 class="standard-tile-teaser__headline podcast-overview-teaser__headline--security">Der Security Podcast</h2>
+                        <p class="standard-tile-teaser__text podcast-overview-teaser__text--security">
+                            In dieser Serie sprechen wir über die Grundlagen von IT-Security. Ein praktischer Einstieg für alle, die an Software arbeiten.
+                        </p>
+                    </div>
+                    <div class="standard-tile-teaser__goto">
+                        <span class="link-teaser link-teaser--security">Alle Episoden</span>
+                    </div>
+                </div>
+            </a>
+        </div>
+        <div class="grid-item4">
+            <div class="podcast-overview-flex">
+                <a href="#" class="podcast-teaser podcast-teaser--avatar--overlay podcast-teaser--avatar--overlay--security flex-grow" style={cssRight}>
+                    <div class="podcast-teaser__body">
+                        <div class="podcast-teaser__caption podcast-teaser__caption--security">Security Podcast</div>
+                        <h2 class="podcast-teaser__headline podcast-teaser__headline--security">Podcast Headline</h2>
+                        <h3 class="podcast-teaser__subheadline podcast-teaser__subheadline--security">
+                            Podcast Subheadline
+                        </h3>
+                        <span class="icon-svg icon-arrow-long-right icon--brand-black"></span>
+                    </div>
+                    <div class="podcast-teaser__footer">
+                        <div class="podcast-author" itemscope itemtype="http://schema.org/Person" >
+                            Heribert Innoq
+                        </div>
+                    </div>
+                </a>
+
+                <a href="#" class="podcast-teaser podcast-teaser--default podcast-teaser--default--security flex-grow">
+                    <div class="podcast-teaser__body">
+                        <div class="podcast-teaser__caption">Security-Podcast</div>
+                        <h2 class="podcast-teaser__headline podcast-teaser__headline--security">Podcast Headline</h2>
+                        <h3 class="podcast-teaser__subheadline podcast-teaser__subheadline--security">
+                            Podcast Subheadline
+                        </h3>
+                        <span class="icon-svg icon-arrow-long-right icon--brand-yellow"></span>
+                    </div>
+                    <div class="podcast-teaser__footer">
+                        <div class="podcast-author" itemscope itemtype="http://schema.org/Person" >
+                            Heribert Innoq
+                        </div>
+                        <div class="podcast-author" itemscope itemtype="http://schema.org/Person" >
+                            Heribert Innoq
+                        </div>
+                    </div>
+                </a>
+                <a href="#" class="podcast-teaser podcast-teaser--default podcast-teaser--default--security flex-grow">
+                    <div class="podcast-teaser__body">
+                        <div class="podcast-teaser__caption">Security-Podcast</div>
+                        <h2 class="podcast-teaser__headline podcast-teaser__headline--security">Podcast Headline</h2>
+                        <h3 class="podcast-teaser__subheadline podcast-teaser__subheadline--security">
+                            Podcast Subheadline
+                        </h3>
+                        <span class="icon-svg icon-arrow-long-right icon--brand-yellow"></span>
+                    </div>
+                    <div class="podcast-teaser__footer">
+                        <div class="podcast-author" itemscope itemtype="http://schema.org/Person" >
+                            Heribert Innoq
+                        </div>
+                        <div class="podcast-author" itemscope itemtype="http://schema.org/Person" >
+                            Heribert Innoq
+                        </div>
+                    </div>
+                </a>
+            </div>
+        </div>
+    </div>
+</main>

--- a/lib/styles/index.scss
+++ b/lib/styles/index.scss
@@ -201,6 +201,8 @@
 @import '../components/02-molecules/visual-elements/teaser/tile-teaser/event-tile-teaser/event-tile-teaser';
 @import '../components/02-molecules/visual-elements/teaser/tile-teaser/podcast-tile-teaser/podcast-tile-teaser';
 @import '../components/02-molecules/visual-elements/teaser/tile-teaser/simple-tile-teaser/simple-tile-teaser';
+@import '../components/02-molecules/visual-elements/teaser/tile-teaser/standard-tile-teaser/standard-tile-teaser';
+
 
 @import '../components/02-molecules/visual-elements/visual-divider/image-divider-center/image-divider-center';
 @import '../components/02-molecules/visual-elements/visual-divider/image-divider-right/image-divider-right';
@@ -232,6 +234,7 @@
 @import '../components/04-pages/error-pages/error-page';
 @import '../components/04-pages/landing-page/landing-page';
 @import '../components/04-pages/magazine-page/magazine-page';
+@import '../components/04-pages/podcast-pages/podcast-overview-page/podcast-overview-page';
 @import '../components/04-pages/podcast-pages/innoq-podcast/innoq-podcast-overview-page/innoq-podcast-overview-page';
 @import '../components/04-pages/podcast-pages/innoq-podcast/innoq-podcast-detail-page/innoq-podcast-detail-page';
 @import '../components/04-pages/podcast-pages/security-podcast/security-podcast-overview-page/security-podcast-overview-page';


### PR DESCRIPTION
- **Standard Tile Teaser ergänzt**: der Case Tile Teaser wird jetzt davon abgeleitet (hier ist noch nicht alles aufgeräumt, würde ich bei Approval machen
- **Podcast Overview Seite ergänzt**: 
  - bei kleinen Screens nur die Übersichtsteaser sichtbar
  - bei größeren Screens 2 x 2 Grid mit den Übersichtsteasern und darunter jeweils Podcaststiles (Menge nicht fixiert, aktuell 3-4) im Flexlayout. Disclaimer: das bricht aus unserem üblichen Teaser-Design aus, ich tendiere dazu, wieder zurück zur Blocks-Klasse mit fixierten Kachelmengen zu gehen.  