### PR TITLE
We need to strip refs/tags/ to get real tag name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,7 +41,7 @@ jobs:
     - run: yarn test
 
   publish:
-    if: ${{ startsWith(github.ref, 'v') }}
+    if: ${{ contains(github.ref, 'refs/tags') }}
     needs: build
     runs-on: ubuntu-latest
 
@@ -73,16 +73,19 @@ jobs:
       env:
         NPM_AUTH_TOKEN: ${{ secrets.NPM_AUTH_TOKEN }}
     - run: ./scripts/dist
+    - name: Get current tag name
+      id: tag_name
+      uses: dawidd6/action-get-tag@v1 
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1
       env:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # This token is provided by Actions, you do not need to create your own token
       with:
-        tag_name: ${{ github.ref }}
-        release_name: ${{ github.ref }}
+        tag_name: ${{ steps.tag_name.outputs.tag }}
+        release_name: ${{ steps.tag_name.outputs.tag }}
         body: |
-          Release ${{ github.ref }}
+          Release ${{ steps.tag_name.outputs.tag }}
         draft: false
         prerelease: false
     - name: Upload Release Asset
@@ -92,6 +95,6 @@ jobs:
         GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
       with:
         upload_url: ${{ steps.create_release.outputs.upload_url }} # This pulls from the CREATE RELEASE step above, referencing it's ID to get its outputs object, which include a `upload_url`. See this blog post for more info: https://jasonet.co/posts/new-features-of-github-actions/#passing-data-to-future-steps
-        asset_path: innoq-styleguide-${{ github.ref }}.zip
-        asset_name: innoq-styleguide-${{ github.ref }}.zip
+        asset_path: innoq-styleguide-${{ steps.tag_name.outputs.tag }}.zip
+        asset_name: innoq-styleguide-${{ steps.tag_name.outputs.tag }}.zip
         asset_content_type: application/zip

--- a/scripts/dist
+++ b/scripts/dist
@@ -7,6 +7,7 @@ rm_rf "dist"
 
 commit = ENV["GITHUB_SHA"]
 tag = ENV.fetch("GITHUB_REF") { "HEAD" }
+tag = tag.gsub("refs/tags/", "")
 js_components_target = "dist/js/components"
 release_filename = "innoq-styleguide-#{tag}.zip"
 zip_blacklist = "-x #{File.read(".npmignore").gsub(/\n/, ' ')}"


### PR DESCRIPTION
Another follow up to #71 

Just calling `github.ref` will yield `refs/tags/v...` which is not want we want. We need to strip `refs/tags/` to get the actual tag name.