### PR TITLE
Deploy `dist/site` to GitHub Pages

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,6 +41,7 @@ jobs:
     - run: yarn test
 
   deploy_site:
+    if: ${{ contains(github.ref, 'refs/tags') }}
     needs: build
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -40,6 +40,41 @@ jobs:
       run: yarn install --frozen-lockfile
     - run: yarn test
 
+  deploy_site:
+    needs: build
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [14.x]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: Setup cache for npm
+      id: npm_cache
+      uses: actions/cache@v2
+      with:
+        path: |
+          ~/.npm
+          ~/cache
+          !~/cache/exclude
+          **/node_modules
+        key: yarn-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
+    - name: yarn install
+      if: steps.npm_cache.outputs.cache-hit != 'true'
+      run: yarn install --frozen-lockfile
+    - run: ./scripts/dist
+    - name: Deploy
+      uses: JamesIves/github-pages-deploy-action@3.7.1
+      with:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        BRANCH: gh-pages # The branch the action should deploy to.
+        FOLDER: dist/site # The folder the action should deploy.
+        CLEAN: true # Automatically remove deleted files from the deploy branch
+
   publish:
     if: ${{ contains(github.ref, 'refs/tags') }}
     needs: build
@@ -75,7 +110,7 @@ jobs:
     - run: ./scripts/dist
     - name: Get current tag name
       id: tag_name
-      uses: dawidd6/action-get-tag@v1 
+      uses: dawidd6/action-get-tag@v1
     - name: Create Release
       id: create_release
       uses: actions/create-release@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,8 @@ jobs:
       if: steps.npm_cache.outputs.cache-hit != 'true'
       run: yarn install --frozen-lockfile
     - run: ./scripts/dist
+      env:
+        SKIP_RELEASE_BUNLDE: true
     - name: Deploy
       uses: JamesIves/github-pages-deploy-action@3.7.1
       with:

--- a/scripts/dist
+++ b/scripts/dist
@@ -27,8 +27,10 @@ cp_r "lib/styles", "dist/sass"
 
 File.write "dist/site/RELEASE.txt", commit
 
-cd "dist" do
-   exit 1 unless system("zip -r #{release_filename} . #{zip_blacklist}")
- end
+unless ENV["SKIP_RELEASE_BUNLDE"].to_s == "true"
+  cd "dist" do
+    exit 1 unless system("zip -r #{release_filename} . #{zip_blacklist}")
+  end
 
-mv "./dist/#{release_filename}", "./"
+  mv "./dist/#{release_filename}", "./"
+end


### PR DESCRIPTION
Since we moved to GitHub Actions (see #71) we dropped publishing `dist/site` to S3. Since this involves another dependency and secrets to be shared we decided to publish to GitHub Pages instead.

This PR introduces a build step that uses a [dedicated action](https://github.com/marketplace/actions/deploy-to-github-pages) for this.

The published page is currently available under https://innoq.github.io/innoq-styleguide/. We should add our custom domain though.