### PR TITLE
Node 10 -> Node 14 (LTS) in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:10
+FROM node:14
 
 WORKDIR /app
 


### PR DESCRIPTION
Trying to run the application as Docker container failed because of an error while executing `yarn install`: 

_error faucet-pipeline-core@1.6.1: The engine "node" is incompatible with this module. Expected version ">= 12". Got "10.24.1"
error Found incompatible module._

Updated the Dockerfile with node:14 image. So far there doesn't seem to be any problem, tests still pass.