### PR TITLE
Patch slider

### DIFF
--- a/components/04-molecules/visual-elements/slider/_slider.scss
+++ b/components/04-molecules/visual-elements/slider/_slider.scss
@@ -19,10 +19,11 @@
 }
 
 .slider__page {
-  border-width: 1px;
+  border-width: 0.5px;
+  border-style: solid;
   border-color: $brand-muted;
-  border-right-style: solid;
   margin-bottom: 0;
+  line-height: 0;
 }
 
 .slider:focus {
@@ -31,17 +32,15 @@
 
 .page__number__box {
   position: absolute;
-  top: 4%;
-  width: 10%;
-  margin-right: 3%;
-  margin-left: 90%;
+  top: 3%;
+  width: 4%;
+  margin-left: 94%;
 }
 
 .page__number {
   @extend %heading-font-regular;
 
   display: inline-block;
-  padding: $spacer-xxs;
   background: rgba(247, 247, 247, 0.7);
   font-size: $font-size-xxs;
 }
@@ -61,8 +60,8 @@
   text-align: center;
 }
 
-.slider:focus+.slider__instructions .instructions--focus,
-.slider:hover+.slider__instructions .instructions--hover {
+.slider:focus:not(:hover)+.slider__instructions .instructions--focus,
+.slider:hover:not(:focus)+.slider__instructions .instructions--hover {
   display: block;
 }
 
@@ -70,15 +69,7 @@
   display: block;
 }
 
-.slider:hover:focus+.slider__instructions .instructions--hover {
-  display: none;
-}
-
-.slider:hover:focus+.slider__instructions .instructions--focus {
-  display: none;
-}
-
-.instructions--touch-active .slider__instructions .instructions--hover-and-focus {
+.instructions--touch-active .instructions__no-touch {
   /* stylelint-disable-next-line */
   display: none !important;
 }

--- a/components/04-molecules/visual-elements/slider/_slider.scss
+++ b/components/04-molecules/visual-elements/slider/_slider.scss
@@ -30,11 +30,8 @@
 }
 
 .page__number__box {
-  position: absolute;
-  top: 4%;
-  width: 10%;
-  margin-right: 3%;
-  margin-left: 90%;
+  margin-top: $spacer-sm;
+  margin-right: auto;
 }
 
 .page__number {

--- a/components/04-molecules/visual-elements/slider/_slider.scss
+++ b/components/04-molecules/visual-elements/slider/_slider.scss
@@ -32,9 +32,8 @@
 .page__number__box {
   position: absolute;
   top: 4%;
-  width: 10%;
-  margin-right: 3%;
-  margin-left: 90%;
+  width: 2%;
+  margin: auto;
 }
 
 .page__number {

--- a/components/04-molecules/visual-elements/slider/_slider.scss
+++ b/components/04-molecules/visual-elements/slider/_slider.scss
@@ -32,8 +32,9 @@
 .page__number__box {
   position: absolute;
   top: 4%;
-  width: 2%;
-  margin: auto;
+  width: 10%;
+  margin-right: 3%;
+  margin-left: 90%;
 }
 
 .page__number {

--- a/components/04-molecules/visual-elements/slider/_slider.scss
+++ b/components/04-molecules/visual-elements/slider/_slider.scss
@@ -30,8 +30,11 @@
 }
 
 .page__number__box {
-  margin-top: $spacer-sm;
-  margin-right: auto;
+  position: absolute;
+  top: 4%;
+  width: 10%;
+  margin-right: 3%;
+  margin-left: 90%;
 }
 
 .page__number {

--- a/components/04-molecules/visual-elements/slider/slider.html
+++ b/components/04-molecules/visual-elements/slider/slider.html
@@ -5,9 +5,9 @@
                 <figure class="slider__page">
                     <img src={context.app.uri("assets/example-content/beispiel-praesentation-1.jpg")} alt="Folie 1" id="Folie_1"/>
                     <figcaption class="page__number__box">
-                        <div class="page__number">
-                            1/4
-                        </div>
+                        <svg class="page__number" viewBox="0 0 45 30" version="1.1" baseProfile="full" xmlns="https://www.w3.org/2000/svg">
+                            <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle">1/4</text>
+                        </svg>
                     </figcaption>
                 </figure>
             </li>
@@ -15,9 +15,9 @@
                 <figure class="slider__page">
                     <img src={context.app.uri("assets/example-content/beispiel-praesentation-2.jpg")} alt="Folie 2" id="Folie_2"/>
                     <figcaption class="page__number__box">
-                        <div class="page__number">
-                            2/4
-                        </div>
+                        <svg class="page__number" viewBox="0 0 45 30" version="1.1" baseProfile="full" xmlns="https://www.w3.org/2000/svg">
+                            <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle">2/4</text>
+                        </svg>
                     </figcaption>
                 </figure>
             </li>
@@ -25,8 +25,8 @@
                 <figure class="slider__page">
                     <img src={context.app.uri("assets/example-content/beispiel-praesentation-3.jpg")} alt="Folie 3" id="Folie_3"/>
                     <figcaption class="page__number__box">
-                        <svg viewBox="0 0 30 20" version="1.1" baseProfile="full" class="page__number" xmlns="https://www.w3.org/2000/svg" width="45" height="35">
-                            <text x="50%" y="60%" dominant-baseline="middle" text-anchor="middle">3/4</text>
+                        <svg class="page__number" viewBox="0 0 45 30" version="1.1" baseProfile="full" xmlns="https://www.w3.org/2000/svg">
+                            <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle">3/4</text>
                         </svg>
                     </figcaption>
                 </figure>
@@ -35,9 +35,9 @@
                 <figure class="slider__page">
                     <img src={context.app.uri("assets/example-content/beispiel-praesentation-4.jpg")} alt="Folie 4" id="Folie_4"/>
                     <figcaption class="page__number__box">
-                        <div class="page__number">
-                            4/4
-                        </div>
+                        <svg class="page__number" viewBox="0 0 45 30" version="1.1" baseProfile="full" xmlns="https://www.w3.org/2000/svg">
+                            <text x="50%" y="55%" dominant-baseline="middle" text-anchor="middle">4/4</text>
+                        </svg>
                     </figcaption>
                 </figure>
             </li>
@@ -45,9 +45,11 @@
     </div>
     <div class="slider__instructions">
         <p class="instructions--touch">Nach links wischen, um ggf. weitere Folien zu sehen</p>
-        <p class="instructions--hover-and-focus">Scrollen oder die Pfeiltasten nutzen, um ggf. weitere Folien zu sehen</p>
-        <p class="instructions--hover">Scrollen, um ggf. weitere Folien zu sehen</p>
-        <p class="instructions--focus">Die Pfeiltasten nutzen, um ggf. weitere Folien zu sehen</p>
+        <div class="instructions__no-touch">
+            <p class="instructions--hover-and-focus">Scrollen oder die Pfeiltasten nutzen, um ggf. weitere Folien zu sehen</p>
+            <p class="instructions--hover">Scrollen, um ggf. weitere Folien zu sehen</p>
+            <p class="instructions--focus">Die Pfeiltasten nutzen, um ggf. weitere Folien zu sehen</p>
+        </div>
     </div>
 </touch-detection>
 {/* This slider relies heavily on https://inclusive-components.design/a-content-slider/, accessed last: 06/15/2021, 16:45. Thanks to Heydon Pickering! */}

--- a/components/04-molecules/visual-elements/slider/slider.html
+++ b/components/04-molecules/visual-elements/slider/slider.html
@@ -25,9 +25,9 @@
                 <figure class="slider__page">
                     <img src={context.app.uri("assets/example-content/beispiel-praesentation-3.jpg")} alt="Folie 3" id="Folie_3"/>
                     <figcaption class="page__number__box">
-                        <div class="page__number">
-                            3/4
-                        </div>
+                        <svg class="page__number">
+                            <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle">3/4</text>
+                        </svg>
                     </figcaption>
                 </figure>
             </li>
@@ -43,7 +43,7 @@
             </li>
         </ul>
     </div>
-    <div class="slider__instructions" id="slider-instructions">
+    <div class="slider__instructions">
         <p class="instructions--touch">Nach links wischen, um ggf. weitere Folien zu sehen</p>
         <p class="instructions--hover-and-focus">Scrollen oder die Pfeiltasten nutzen, um ggf. weitere Folien zu sehen</p>
         <p class="instructions--hover">Scrollen, um ggf. weitere Folien zu sehen</p>

--- a/components/04-molecules/visual-elements/slider/slider.html
+++ b/components/04-molecules/visual-elements/slider/slider.html
@@ -25,8 +25,8 @@
                 <figure class="slider__page">
                     <img src={context.app.uri("assets/example-content/beispiel-praesentation-3.jpg")} alt="Folie 3" id="Folie_3"/>
                     <figcaption class="page__number__box">
-                        <svg class="page__number">
-                            <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle">3/4</text>
+                        <svg viewBox="0 0 30 20" version="1.1" baseProfile="full" class="page__number" xmlns="https://www.w3.org/2000/svg" width="45" height="35">
+                            <text x="50%" y="60%" dominant-baseline="middle" text-anchor="middle">3/4</text>
                         </svg>
                     </figcaption>
                 </figure>

--- a/components/04-molecules/visual-elements/slider/slider.html
+++ b/components/04-molecules/visual-elements/slider/slider.html
@@ -1,5 +1,5 @@
 <touch-detection>
-    <div class="slider" role="region" aria-label="Folien" tabindex="0" aria-describedby="slider-instructions">
+    <div class="slider" role="region" aria-label="Folien" tabindex="0" aria-describedby="slider__instructions">
         <ul class="slider__all">
             <li class="slider__slide">
                 <figure class="slider__page">

--- a/components/04-molecules/visual-elements/slider/slider.html
+++ b/components/04-molecules/visual-elements/slider/slider.html
@@ -1,5 +1,5 @@
 <touch-detection>
-    <div class="slider" role="region" aria-label="Folien" tabindex="0" aria-describedby="slider__instructions">
+    <div class="slider" role="region" aria-label="Folien" tabindex="0" aria-describedby="slider-instructions">
         <ul class="slider__all">
             <li class="slider__slide">
                 <figure class="slider__page">
@@ -43,7 +43,7 @@
             </li>
         </ul>
     </div>
-    <div class="slider__instructions">
+    <div class="slider__instructions" id="slider-instructions">
         <p class="instructions--touch">Nach links wischen, um ggf. weitere Folien zu sehen</p>
         <p class="instructions--hover-and-focus">Scrollen oder die Pfeiltasten nutzen, um ggf. weitere Folien zu sehen</p>
         <p class="instructions--hover">Scrollen, um ggf. weitere Folien zu sehen</p>


### PR DESCRIPTION
Dieser Patch behebt einen kleinen Rand unter dem Bild, ein Problem mit dem Screenreader, ein kurzes Aufflackern des falschen Instruktionstextes  bei fokussiertem Slider in der Mobilansicht, wenn man wieder in die Browserapp geht, verzichtet auf einige CSS-Klassen und macht die Seitenzahl responsiv. 
Das Beheben des Rands unter dem Bild hat nur mit `line-height: 0;` in der umgebenden Klasse geklappt, das fühlt sich hacky an, ich habe aber keine gute Alternative gefunden. 