### PR TITLE
use brand-petrol with 30% opacity for punch-in texts to improve reada…

### DIFF
--- a/lib/styles/02-util/_text.scss
+++ b/lib/styles/02-util/_text.scss
@@ -124,7 +124,7 @@
 @supports (background-clip: text) or (-webkit-background-clip: text) {
   .punch-in,
   %punch-in {
-    color: transparent;
+    color: rgba($brand-petrol, 0.3);
     background-position: center;
     /* stylelint-disable-next-line property-no-vendor-prefix */
     -webkit-background-clip: text;

--- a/lib/styles/02-util/_text.scss
+++ b/lib/styles/02-util/_text.scss
@@ -124,7 +124,7 @@
 @supports (background-clip: text) or (-webkit-background-clip: text) {
   .punch-in,
   %punch-in {
-    color: rgba($brand-petrol, 0.3);
+    color: rgba($brand-secondary, 0.3);
     background-position: center;
     /* stylelint-disable-next-line property-no-vendor-prefix */
     -webkit-background-clip: text;


### PR DESCRIPTION
Punch-in texts on background images are often hard to read.
To improve readability, I propose to use the brand-petrol color with 30% opacity for the text.